### PR TITLE
Add working directory to test search paths

### DIFF
--- a/t/14_simple_unix.t
+++ b/t/14_simple_unix.t
@@ -1,6 +1,9 @@
 use warnings;
 use strict;
 
+use FindBin;
+use lib "$FindBin::Bin/../";
+
 BEGIN {
     if ($^O =~ m/^(?:qnx|nto|vos|MSWin32)$/ ) {
         print "1..0 # Skip: UNIX domain sockets not implemented on $^O\n";

--- a/t/15_oo_unix.t
+++ b/t/15_oo_unix.t
@@ -1,6 +1,9 @@
 use warnings;
 use strict;
 
+use FindBin;
+use lib "$FindBin::Bin/../";
+
 BEGIN {
     if ($^O =~ m/^(?:qnx|nto|vos|MSWin32)$/ ) {
         print "1..0 # Skip: UNIX domain sockets not implemented on $^O\n";


### PR DESCRIPTION
 Tests 14 and 15 fail to run on recent versions of Perl following the removal
 of '.' from @INC in response to CVE-2016-1238. This patch follows the
 recommended solution of using FindBin to find the relative path.

Closes #1 