### PR TITLE
Stop server before exiting in test (fixes #3)

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Perl extension Test-UNIXSock
 
 {{$NEXT}}
+    - Fix intermittent test failure (GH#3)
 
 0.2 2017-05-31T00:45:02Z
     - Fix tests. (#2 mans0954)

--- a/t/15_oo_unix.t
+++ b/t/15_oo_unix.t
@@ -47,4 +47,6 @@ is $res2, "bar\n";
 note "finalize";
 print {$sock} "quit\n";
 
+$server->stop;
+
 done_testing;


### PR DESCRIPTION
There's a race condition between the parent and child exiting if we
let the server run until global destruction, causing Test2 to throw errors
about left-over files in the IPC directory.